### PR TITLE
Fix incorrect images check in Services

### DIFF
--- a/layouts/partials/Services.js
+++ b/layouts/partials/Services.js
@@ -27,7 +27,7 @@ const Services = ({ services }) => {
                   delay: 5000,
                   disableOnInteraction: false,
                 }}
-                init={service?.images > 1 ? false : true}
+                init={service?.images.length > 1 ? false : true}
               >
                 {/* Slides */}
                 {service?.images.map((slide, index) => (


### PR DESCRIPTION
## Summary
- ensure Swiper initializes correctly by comparing the image array length

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68794d03fb108322ada606746a0768ab